### PR TITLE
Fix/video play buttons missing

### DIFF
--- a/src/components/patterns/megalinks/Megalinks.vue
+++ b/src/components/patterns/megalinks/Megalinks.vue
@@ -409,6 +409,9 @@ export default {
                                     <VsVideo
                                         videoId="N3r5rCN9iaE"
                                         class="mb-8"
+                                        no-js-message="You need Javascript enabled"
+                                        no-cookies-message="You need cookies enabled"
+                                        cookie-btn-text="Cookie button"
                                     />
                                 </VsCol>
                             </VsRow>
@@ -590,6 +593,9 @@ export default {
                                     <VsVideo
                                         videoId="N3r5rCN9iaE"
                                         class="mb-8"
+                                        no-js-message="You need Javascript enabled"
+                                        no-cookies-message="You need cookies enabled"
+                                        cookie-btn-text="Cookie button"
                                     />
                                 </VsCol>
                             </VsRow>
@@ -691,6 +697,9 @@ export default {
                         <VsVideo
                             videoId="tfk7J6XZju4"
                             class="mb-8"
+                            no-js-message="You need Javascript enabled"
+                            no-cookies-message="You need cookies enabled"
+                            cookie-btn-text="Cookie button"
                         />
                     </VsCol>
                 </VsRow>
@@ -750,6 +759,9 @@ export default {
                         <VsVideo
                             videoId="zZCUFjSiWpE"
                             class="mb-8"
+                            no-js-message="You need Javascript enabled"
+                            no-cookies-message="You need cookies enabled"
+                            cookie-btn-text="Cookie button"
                         />
                     </VsCol>
                 </VsRow>

--- a/src/components/patterns/stretched-link-card/StretchedLinkCard.vue
+++ b/src/components/patterns/stretched-link-card/StretchedLinkCard.vue
@@ -105,7 +105,7 @@
                 size="md"
                 ref="videoShow"
                 @click.native="emitShowModal"
-                v-if="videoId && videoLoaded && requiredCookiesExist && !jsDisabled"
+                v-if="videoId && videoLoaded && requiredCookiesExist"
             >
                 <span
                     class="vs-stretched-link-card__video-btn-text"


### PR DESCRIPTION
That check on the play button for whether js is disabled seems to be causing some issues, when mounted in the site it's now failing but it still works in the design system and I'm pretty sure it worked before we split the repos as this stuff was all rebuilt a few months ago. Not sure why that race condition seems to have flipped, but it isn't necessary anyway, if js is disabled videoLoaded will never become true so the button can't appear, and the error message that relies on checking if JS is present seems to work fine still.