### PR TITLE
fix: 🐛 Improve screen reader consistency on form errors

### DIFF
--- a/src/components/elements/checkbox/Checkbox.vue
+++ b/src/components/elements/checkbox/Checkbox.vue
@@ -14,18 +14,23 @@
         />
         <!-- eslint-enable-vue/no-v-html -->
 
-        <span
-            v-for="error in errorsList"
-            :key="error"
-            class="error"
+        <div
+            role="alert"
             aria-live="assertive"
+            v-if="$v.inputVal.$anyError || invalid"
+            :id="`error-${fieldName}`"
         >
-            <template
-                v-if="$v.inputVal.$anyError || invalid"
+            <p
+                v-for="error in errorsList"
+                v-show="!reAlertErrors"
+                :key="error"
+                class="error mb-0"
             >
+                <span class="sr-only">{{ fieldName }}</span>
                 {{ validationMessages[error] || genericValidation[error] }}
-            </template>
-        </span>
+            </p>
+        </div>
+
         <BFormCheckbox
             v-if="fieldName"
             v-model="inputVal"
@@ -40,6 +45,8 @@
             @change="emitStatus"
             :required="isRequired"
             :aria-invalid="$v.inputVal.$anyError || invalid"
+            :aria-describedby="$v.inputVal.$anyError || invalid ?
+                `error-${fieldName}` : `hint-${fieldName}`"
         >
             <span class="vs-checkbox__label">{{ label }}</span>
         </BFormCheckbox>
@@ -156,6 +163,15 @@ export default {
         infoText: {
             type: String,
             default: '',
+        },
+        /**
+         * Whether the parent form has just been submitted, if so all errors
+         * need to be wiped from then re-added to the DOM to inform screen
+         * readers that they should be re-declared
+         */
+        reAlertErrors: {
+            type: Boolean,
+            default: false,
         },
     },
     data() {

--- a/src/components/elements/recaptcha/Recaptcha.vue
+++ b/src/components/elements/recaptcha/Recaptcha.vue
@@ -4,7 +4,7 @@
         aria-live="assertive"
     >
         <span
-            v-if="invalid"
+            v-if="invalid && !reAlertErrors"
             class="error"
         >
             {{ errorMsg }}
@@ -75,6 +75,15 @@ export default {
         textareaLabel: {
             type: String,
             default: 'Does not need any text',
+        },
+        /**
+         * Whether the parent form has just been submitted, if so all errors
+         * need to be wiped from then re-added to the DOM to inform screen
+         * readers that they should be re-declared
+         */
+        reAlertErrors: {
+            type: Boolean,
+            default: false,
         },
     },
     methods: {

--- a/src/components/elements/select/Select.vue
+++ b/src/components/elements/select/Select.vue
@@ -6,18 +6,24 @@
         >
             {{ hintText }}
         </p>
-        <span
-            v-for="error in errorsList"
-            :key="error"
-            class="error"
+
+        <div
+            role="alert"
             aria-live="assertive"
+            v-if="$v.inputVal.$anyError || invalid"
+            :id="`error-${fieldName}`"
         >
-            <template
-                v-if="$v.inputVal.$anyError || invalid"
+            <p
+                v-for="error in errorsList"
+                v-show="!reAlertErrors"
+                :key="error"
+                class="error mb-0"
             >
+                <span class="sr-only">{{ fieldName }}</span>
                 {{ validationMessages[error] || genericValidation[error] }}
-            </template>
-        </span>
+            </p>
+        </div>
+
         <div class="vs-select__container  mt-2">
             <BFormSelect
                 v-model="inputVal"
@@ -31,7 +37,8 @@
                 class="vs-select__element"
                 :required="isRequired"
                 :aria-invalid="$v.inputVal.$anyError || invalid"
-                :aria-describedby="`hint-${fieldName}`"
+                :aria-describedby="$v.inputVal.$anyError || invalid ?
+                    `error-${fieldName}` : `hint-${fieldName}`"
                 :class="errorClass"
                 :autocomplete="autocompleteValue(fieldName)"
             />
@@ -154,6 +161,15 @@ export default {
                 return {
                 };
             },
+        },
+        /**
+         * Whether the parent form has just been submitted, if so all errors
+         * need to be wiped from then re-added to the DOM to inform screen
+         * readers that they should be re-declared
+         */
+        reAlertErrors: {
+            type: Boolean,
+            default: false,
         },
     },
     data() {

--- a/src/components/patterns/marketo-form/MarketoForm.vue
+++ b/src/components/patterns/marketo-form/MarketoForm.vue
@@ -45,6 +45,7 @@
                                     :trigger-validate="triggerValidate"
                                     :hint-text="getTranslatedHint(field.name, index)"
                                     :placeholder="field.placeholder || ''"
+                                    :re-alert-errors="reAlertErrors"
                                 />
                             </template>
 
@@ -63,6 +64,7 @@
                                     :country-list-url="countryListUrl"
                                     :countries="field.countries"
                                     :hint-text="getTranslatedHint(field.name, index)"
+                                    :re-alert-errors="reAlertErrors"
                                 />
                             </template>
 
@@ -85,6 +87,7 @@
                                     :optional-text="getMessagingData('optional', language)"
                                     :hint-text="getTranslatedHint(field.name, index)"
                                     :info-text="getTranslatedInfo(field.name, index)"
+                                    :re-alert-errors="reAlertErrors"
                                 />
                             </template>
                         </div>
@@ -99,6 +102,7 @@
                     :error-msg="getMessagingData('recaptchaError', language)"
                     class="mt-9"
                     :textarea-label="recaptchaTextareaLabel"
+                    :re-alert-errors="reAlertErrors"
                 />
 
                 <VsButton
@@ -276,6 +280,7 @@ export default {
             conditionalFields: {
             },
             inputVal: '',
+            reAlertErrors: false,
         };
     },
     computed: {
@@ -600,6 +605,11 @@ export default {
                 this.marketoSubmit();
             } else {
                 this.showErrorMessage = true;
+                this.reAlertErrors = true;
+
+                setTimeout(() => {
+                    this.reAlertErrors = false;
+                }, 100);
             }
         },
         /**


### PR DESCRIPTION
This re-implements some work that I did in November that makes error messages alert to screen readers more consistently, and re-alert if you submit a form without having cleared all of them. I'm not sure where that disappeared to I guess it maybe got dropped out somewhere as it was only a week before the initial commit in this repo. I've also set error messages on inputs to clear when you focus the input then reappear when they blur, otherwise you get some situations where SRs can't tell if an error message changes (e.g. you tab out of an email box, it says it's required, you tab back and type something, the error changes to "type something that looks like an email address" but it doesn't realert you because it's busy reading what you're typing)

https://bitbucket.visitscotland.com/projects/VSCOM/repos/visitscotland-2019/pull-requests/995/overview 