### PR TITLE
🐛fix(analytics): stop trying to set clickText when no js event present

### DIFF
--- a/src/mixins/dataLayerMixin.js
+++ b/src/mixins/dataLayerMixin.js
@@ -68,10 +68,12 @@ const dataLayerMixin = {
             let dataLayerData;
             let clickText;
 
-            if (event.target.text) {
-                clickText = event.target.text.trim();
-            } else {
-                clickText = event.target.innerText;
+            if (event) {
+                if (event.target.text) {
+                    clickText = event.target.text.trim();
+                } else {
+                    clickText = event.target.innerText;
+                }
             }
 
             switch (type) {


### PR DESCRIPTION
Page view and form submission events don't pass a js event to the analytics code, so this was failing. The submission of the form completely then fails to proceed (and other events aren't submitting to GA)