### PR TITLE
Feat/vsd 313 review bootstrap comp usage

### DIFF
--- a/src/components/elements/grid/Row.vue
+++ b/src/components/elements/grid/Row.vue
@@ -1,13 +1,14 @@
 <template>
-    <BRow v-bind="$attrs">
+    <div
+        class="row"
+        v-bind="$attrs"
+    >
         <!-- @slot Default slot for row content -->
         <slot />
-    </BRow>
+    </div>
 </template>
 
 <script>
-import { BRow } from 'bootstrap-vue';
-
 /**
  * Rows are used to wrap column elements to ensure consistent alignment.
  *
@@ -18,9 +19,6 @@ export default {
     name: 'VsRow',
     status: 'prototype',
     release: '0.0.1',
-    components: {
-        BRow,
-    },
 };
 </script>
 

--- a/src/components/elements/grid/__tests__/Row.jest.spec.js
+++ b/src/components/elements/grid/__tests__/Row.jest.spec.js
@@ -16,8 +16,8 @@ beforeEach(() => {
 });
 
 describe('VsButton', () => {
-    it('should render a brow-stub', () => {
-        expect(wrapper.element.tagName).toBe('BROW-STUB');
+    it('should render a div', () => {
+        expect(wrapper.element.tagName).toBe('DIV');
     });
 
     describe(':slots', () => {

--- a/src/components/elements/panel/Panel.vue
+++ b/src/components/elements/panel/Panel.vue
@@ -8,15 +8,15 @@
             <slot name="vs-panel-title" />
         </template>
 
-        <BCardText class="vs-panel__text">
+        <div class="vs-panel__text">
             <!-- @slot Default slot containing main body text -->
             <slot />
-        </BCardText>
+        </div>
     </BCard>
 </template>
 
 <script>
-import { BCard, BCardText } from 'bootstrap-vue';
+import { BCard } from 'bootstrap-vue';
 
 /**
  * The panel component is a container
@@ -30,7 +30,6 @@ export default {
     release: '0.0.1',
     components: {
         BCard,
-        BCardText,
     },
 };
 </script>

--- a/src/components/elements/panel/__tests__/Panel.jest.spec.js
+++ b/src/components/elements/panel/__tests__/Panel.jest.spec.js
@@ -32,13 +32,6 @@ describe('VsPanel', () => {
         expect(wrapper.element.tagName).toBe('BCARD-STUB');
     });
 
-    it('should render a bcardtext-stub', () => {
-        const wrapper = factoryShallowMount();
-        const cardTextStub = wrapper.find('bcardtext-stub');
-
-        expect(cardTextStub.exists()).toBe(true);
-    });
-
     describe(':slots', () => {
         it('renders content inserted into default `slot`', () => {
             const wrapper = factoryShallowMount();


### PR DESCRIPTION
As a follow up to the link change, I've reviewed the rest of our bootstrap vue comp usage. These two are the only ones which can be unambiguously removed:

* Row mostly just adds a .row class, there is also a no-gutters option but we haven't used it anywhere. The one place we've set no gutters in the meganav we've directly added the class
* The card text isn't being used appropriately anyway in that panel, it creates some weirdly formed html where we have a p containing a div containing another set of ps. That means that any changes to padding that the card text gives are overridden anyway so it isn't actually doing anything.

The only other possible candidate I could see is the container, which just sets .container on a div 90% of the time. In a handful of cases though we're using the fluid option which adds more complex conditional classes. I don't think it's particularly worth redoing all of that at this point, and potentially limiting ourselves in the future.